### PR TITLE
under construction, added 2 untested functions

### DIFF
--- a/.github/actions/javascript/postTestCoverageComment/index.js
+++ b/.github/actions/javascript/postTestCoverageComment/index.js
@@ -31811,75 +31811,210 @@ function generateCoverageData(coverage, changedFiles, baseCoverage) {
 }
 
 /**
- * Generate enhanced coverage section markdown using template
+ * Simple mustache-like template engine
+ */
+function renderTemplate(template, data) {
+    let result = template;
+    
+    // Handle conditional blocks {{#condition}} ... {{/condition}}
+    result = result.replace(/\{\{#([^}]+)\}\}([\s\S]*?)\{\{\/\1\}\}/g, (match, condition, content) => {
+        const value = getNestedValue(data, condition);
+        return value ? renderTemplate(content, data) : '';
+    });
+    
+    // Handle inverted conditional blocks {{^condition}} ... {{/condition}}
+    result = result.replace(/\{\{\^([^}]+)\}\}([\s\S]*?)\{\{\/\1\}\}/g, (match, condition, content) => {
+        const value = getNestedValue(data, condition);
+        return !value ? renderTemplate(content, data) : '';
+    });
+    
+    // Handle array iterations {{#array}} ... {{/array}}
+    result = result.replace(/\{\{#([^}]+)\}\}([\s\S]*?)\{\{\/\1\}\}/g, (match, arrayName, content) => {
+        const array = getNestedValue(data, arrayName);
+        if (Array.isArray(array)) {
+            return array.map(item => renderTemplate(content, {...data, ...item})).join('');
+        }
+        return '';
+    });
+    
+    // Handle variable substitutions {{variable}}
+    result = result.replace(/\{\{([^}#^/]+)\}\}/g, (match, variable) => {
+        const value = getNestedValue(data, variable.trim());
+        return value !== undefined ? value : '';
+    });
+    
+    return result;
+}
+
+/**
+ * Get nested value from object using dot notation
+ */
+function getNestedValue(obj, path) {
+    return path.split('.').reduce((current, key) => {
+        return current && current[key] !== undefined ? current[key] : undefined;
+    }, obj);
+}
+
+/**
+ * Generate enhanced coverage section markdown with better formatting
  */
 function generateCoverageSection(coverageData, artifactUrl, workflowRunId) {
     const {overall, changedFiles, baseCoverage} = coverageData;
+    
+    // Local template for easy editing
+    const coverageTemplate = `
+    ### 🧪 Test Coverage Report
 
+    {{#hasBaseline}}
+    {{#status.hasChange}}
+    \`\`\`diff
+    {{#status.isIncrease}}
+    + 📊 Overall Coverage: {{current.lines}}% ↑ (baseline: {{baseline.lines}}%)
+    {{/status.isIncrease}}
+    {{#status.isDecrease}}
+    - 📊 Overall Coverage: {{current.lines}}% ↓ (baseline: {{baseline.lines}}%)
+    {{/status.isDecrease}}
+    \`\`\`
+
+    {{/status.hasChange}}
+    {{/hasBaseline}}
+
+    {{#status.hasChange}}
+    {{status.emoji}} **{{status.text}}**
+    {{#hasBaseline}}
+    📈 Overall Coverage: {{current.lines}}% {{status.arrow}}
+    {{status.changeEmoji}} {{status.changeText}} from baseline
+    {{/hasBaseline}}
+    {{/status.hasChange}}
+    {{^status.hasChange}}
+    {{#hasBaseline}}
+    {{status.emoji}} **{{status.text}}**
+    📊 Overall Coverage: {{current.lines}}% (unchanged)
+    {{/hasBaseline}}
+    {{^hasBaseline}}
+    📊 **Overall Coverage**: {{current.lines}}%
+    {{/hasBaseline}}
+    {{/status.hasChange}}
+
+    <details>
+    <summary>📋 Coverage Details</summary>
+
+    {{#hasChangedFiles}}
+    | File | Coverage | Lines |
+    |------|----------|-------|
+    {{#changedFiles}}
+    | {{displayFile}} | {{coverage}}% | {{lines}} |
+    {{/changedFiles}}
+
+    {{/hasChangedFiles}}
+    {{^hasChangedFiles}}
+    *No changed files with coverage data found.*
+
+    {{/hasChangedFiles}}
+    ### Overall Coverage Summary
+    {{#hasBaseline}}
+    - **Lines**: {{current.lines}}% ({{changes.lines.emoji}} {{changes.lines.text}})
+    - **Statements**: {{current.statements}}% ({{changes.statements.emoji}} {{changes.statements.text}})
+    - **Functions**: {{current.functions}}% ({{changes.functions.emoji}} {{changes.functions.text}})
+    - **Branches**: {{current.branches}}% ({{changes.branches.emoji}} {{changes.branches.text}})
+    {{/hasBaseline}}
+    {{^hasBaseline}}
+    - **Lines**: {{current.lines}}%
+    - **Statements**: {{current.statements}}%
+    - **Functions**: {{current.functions}}%
+    - **Branches**: {{current.branches}}%
+    {{/hasBaseline}}
+
+    </details>
+
+    📄 [View Full Coverage Report]({{links.coverageReport}})
+    🔗 [View Workflow Run Summary]({{links.workflowRun}})
+
+    <!-- END_COVERAGE_SECTION -->`;
+    
+    // Get coverage status for overall lines coverage
     const coverageStatus = getCoverageStatus(overall.lines, baseCoverage?.lines);
-    let coverageSection = '### 📊 Test Coverage Report\n\n';
-
-    if (baseCoverage) {
-        if (coverageStatus.diff !== 0) {
-            const diffPrefix = coverageStatus.diff > 0 ? '+' : '-';
-            coverageSection += '```diff\n';
-            coverageSection += `${diffPrefix} 📊 Overall Coverage: ${overall.lines.toFixed(2)}% ${coverageStatus.diff > 0 ? '↑' : '↓'} (baseline: ${baseCoverage.lines.toFixed(2)}%)\n`;
-            coverageSection += '```\n\n';
+    
+    // Calculate changes for all metrics
+    const changes = baseCoverage ? {
+        lines: calculateChange(overall.lines, baseCoverage.lines),
+        statements: calculateChange(overall.statements, baseCoverage.statements),
+        functions: calculateChange(overall.functions, baseCoverage.functions),
+        branches: calculateChange(overall.branches, baseCoverage.branches)
+    } : {};
+    
+    // Process changed files for template
+    const processedChangedFiles = changedFiles.map(file => ({
+        ...file,
+        displayFile: file.file.length > 50 ? `...${file.file.slice(-47)}` : file.file,
+        coverage: file.coverage.toFixed(1),
+        branches: file.branches || 'N/A'
+    }));
+    
+    const avgChangedCoverage = changedFiles.length > 0 
+        ? (changedFiles.reduce((sum, file) => sum + file.coverage, 0) / changedFiles.length).toFixed(1)
+        : 0;
+    
+    // Prepare template data
+    const templateData = {
+        hasBaseline: !!baseCoverage,
+        hasChangedFiles: changedFiles.length > 0,
+        avgChangedCoverage,
+        
+        current: {
+            lines: overall.lines.toFixed(1),
+            functions: overall.functions.toFixed(1),
+            statements: overall.statements.toFixed(1),
+            branches: overall.branches.toFixed(1)
+        },
+        
+        baseline: baseCoverage ? {
+            lines: baseCoverage.lines.toFixed(2),
+            functions: baseCoverage.functions.toFixed(2),
+            statements: baseCoverage.statements.toFixed(2),
+            branches: baseCoverage.branches.toFixed(2)
+        } : null,
+        
+        status: {
+            emoji: coverageStatus.emoji,
+            text: coverageStatus.status,
+            hasChange: coverageStatus.diff !== 0,
+            isIncrease: coverageStatus.diff > 0,
+            isDecrease: coverageStatus.diff < 0,
+            arrow: coverageStatus.diff > 0 ? '↑' : '↓',
+            changeEmoji: coverageStatus.diff > 0 ? '🚀' : '⚠️',
+            changeText: `${Math.abs(coverageStatus.diff).toFixed(1)}% ${coverageStatus.diff > 0 ? 'gain' : 'drop'}`
+        },
+        
+        changes,
+        changedFiles: processedChangedFiles,
+        
+        links: {
+            coverageReport: artifactUrl,
+            workflowRun: `https://github.com/${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.owner}/${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.repo}/actions/runs/${workflowRunId}`
         }
-
-        coverageSection += `${coverageStatus.emoji} **${coverageStatus.status}**\n`;
-        if (coverageStatus.diff !== 0) {
-            const arrow = coverageStatus.diff > 0 ? '↑' : '↓';
-            const gain = coverageStatus.diff > 0 ? 'gain' : 'drop';
-            coverageSection += `📈 Overall Coverage: ${overall.lines.toFixed(1)}% ${arrow}\n`;
-            coverageSection += `${coverageStatus.diff > 0 ? '🚀' : '⚠️'} ${Math.abs(coverageStatus.diff).toFixed(1)}% ${gain} from baseline\n`;
-        } else {
-            coverageSection += `📊 Overall Coverage: ${overall.lines.toFixed(1)}% (unchanged)\n`;
-        }
-    } else {
-        coverageSection += `📊 **Overall Coverage**: ${overall.lines.toFixed(1)}%\n`;
-    }
-
-    coverageSection += '\n<details>\n<summary>📋 Coverage Details</summary>\n\n';
-
-    if (changedFiles.length > 0) {
-        coverageSection += '| File | Coverage | Lines |\n';
-        coverageSection += '|------|----------|-------|\n';
-
-        changedFiles.forEach((file) => {
-            const displayFile = file.file.length > 50 ? `...${file.file.slice(-47)}` : file.file;
-            coverageSection += `| ${displayFile} | ${file.coverage.toFixed(1)}% | ${file.lines} |\n`;
-        });
-        coverageSection += '\n';
-    } else {
-        coverageSection += '*No changed files with coverage data found.*\n\n';
-    }
-
-    coverageSection += '### Overall Coverage Summary\n';
-
-    const formatMetric = (name, current, base) => {
-        if (!base) {
-            return `- **${name}**: ${current.toFixed(2)}%`;
-        }
-        const diff = current - base;
-        if (Math.abs(diff) < 0.01) {
-            return `- **${name}**: ${current.toFixed(2)}%`;
-        }
-        const sign = diff > 0 ? '+' : '';
-        const emoji = diff > 0 ? '📈' : '📉';
-        return `- **${name}**: ${current.toFixed(2)}% (${emoji} ${sign}${diff.toFixed(2)}%)`;
     };
+    
+    return renderTemplate(coverageTemplate, templateData);
+}
 
-    coverageSection += `${formatMetric('Lines', overall.lines, baseCoverage?.lines)}\n`;
-    coverageSection += `${formatMetric('Statements', overall.statements, baseCoverage?.statements)}\n`;
-    coverageSection += `${formatMetric('Functions', overall.functions, baseCoverage?.functions)}\n`;
-
-    coverageSection += '\n</details>\n\n';
-    coverageSection += `📄 [View Full Coverage Report](${artifactUrl})\n`;
-    coverageSection += `🔗 [View Workflow Run Summary](https://github.com/${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.owner}/${_actions_github__WEBPACK_IMPORTED_MODULE_1__.context.repo.repo}/actions/runs/${workflowRunId})\n`;
-    coverageSection += `\n${COVERAGE_SECTION_END}`;
-
-    return coverageSection;
+/**
+ * Calculate coverage change with formatting
+ */
+function calculateChange(current, baseline) {
+    const diff = current - baseline;
+    if (Math.abs(diff) < 0.01) {
+        return {
+            text: '→ 0.0%',
+            emoji: '→'
+        };
+    }
+    const arrow = diff > 0 ? '↑' : '↓';
+    const emoji = diff > 0 ? '📈' : '📉';
+    return {
+        text: `${diff > 0 ? '+' : ''}${diff.toFixed(2)}%`,
+        emoji: `${emoji} ${arrow} ${Math.abs(diff).toFixed(1)}%`
+    };
 }
 
 /**
@@ -31947,7 +32082,7 @@ async function updatePRBody(octokit, prNumber, coverageSection) {
 /**
  * Get coverage report URL - either from direct input or fallback to workflow artifacts
  */
-function getCoverageUrl(coverageUrl, artifactName, workflowRunId) {
+function getCoverageUrl(coverageUrl, workflowRunId) {
     // If we have a direct URL (e.g., from Surge.sh), use it
     if (coverageUrl) {
         return coverageUrl;
@@ -31966,7 +32101,6 @@ async function run() {
         const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_1__.getOctokit)(githubToken);
 
         const prNumber = parseInt(_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('PR_NUMBER', {required: true}), 10);
-        const coverageArtifactName = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('COVERAGE_ARTIFACT_NAME', {required: false}) || 'coverage-report';
         const baseCoveragePath = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('BASE_COVERAGE_PATH', {required: false});
         const coverageUrl = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('COVERAGE_URL', {required: false});
         const customTemplatePath = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('TEMPLATE_PATH', {required: false});
@@ -31997,7 +32131,7 @@ async function run() {
 
         // Get coverage URL
         const workflowRunId = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.runId.toString();
-        const reportUrl = getCoverageUrl(coverageUrl, coverageArtifactName, workflowRunId);
+        const reportUrl = getCoverageUrl(coverageUrl, workflowRunId);
 
         // Generate coverage section
         const coverageSection = generateCoverageSection(coverageData, reportUrl, workflowRunId, customTemplatePath);

--- a/.github/actions/javascript/postTestCoverageComment/postTestCoverageComment.js
+++ b/.github/actions/javascript/postTestCoverageComment/postTestCoverageComment.js
@@ -96,75 +96,210 @@ function generateCoverageData(coverage, changedFiles, baseCoverage) {
 }
 
 /**
- * Generate enhanced coverage section markdown using template
+ * Simple mustache-like template engine
+ */
+function renderTemplate(template, data) {
+    let result = template;
+    
+    // Handle conditional blocks {{#condition}} ... {{/condition}}
+    result = result.replace(/\{\{#([^}]+)\}\}([\s\S]*?)\{\{\/\1\}\}/g, (match, condition, content) => {
+        const value = getNestedValue(data, condition);
+        return value ? renderTemplate(content, data) : '';
+    });
+    
+    // Handle inverted conditional blocks {{^condition}} ... {{/condition}}
+    result = result.replace(/\{\{\^([^}]+)\}\}([\s\S]*?)\{\{\/\1\}\}/g, (match, condition, content) => {
+        const value = getNestedValue(data, condition);
+        return !value ? renderTemplate(content, data) : '';
+    });
+    
+    // Handle array iterations {{#array}} ... {{/array}}
+    result = result.replace(/\{\{#([^}]+)\}\}([\s\S]*?)\{\{\/\1\}\}/g, (match, arrayName, content) => {
+        const array = getNestedValue(data, arrayName);
+        if (Array.isArray(array)) {
+            return array.map(item => renderTemplate(content, {...data, ...item})).join('');
+        }
+        return '';
+    });
+    
+    // Handle variable substitutions {{variable}}
+    result = result.replace(/\{\{([^}#^/]+)\}\}/g, (match, variable) => {
+        const value = getNestedValue(data, variable.trim());
+        return value !== undefined ? value : '';
+    });
+    
+    return result;
+}
+
+/**
+ * Get nested value from object using dot notation
+ */
+function getNestedValue(obj, path) {
+    return path.split('.').reduce((current, key) => {
+        return current && current[key] !== undefined ? current[key] : undefined;
+    }, obj);
+}
+
+/**
+ * Generate enhanced coverage section markdown with better formatting
  */
 function generateCoverageSection(coverageData, artifactUrl, workflowRunId) {
     const {overall, changedFiles, baseCoverage} = coverageData;
+    
+    // Local template for easy editing
+    const coverageTemplate = `
+    ### 🧪 Test Coverage Report
 
+    {{#hasBaseline}}
+    {{#status.hasChange}}
+    \`\`\`diff
+    {{#status.isIncrease}}
+    + 📊 Overall Coverage: {{current.lines}}% ↑ (baseline: {{baseline.lines}}%)
+    {{/status.isIncrease}}
+    {{#status.isDecrease}}
+    - 📊 Overall Coverage: {{current.lines}}% ↓ (baseline: {{baseline.lines}}%)
+    {{/status.isDecrease}}
+    \`\`\`
+
+    {{/status.hasChange}}
+    {{/hasBaseline}}
+
+    {{#status.hasChange}}
+    {{status.emoji}} **{{status.text}}**
+    {{#hasBaseline}}
+    📈 Overall Coverage: {{current.lines}}% {{status.arrow}}
+    {{status.changeEmoji}} {{status.changeText}} from baseline
+    {{/hasBaseline}}
+    {{/status.hasChange}}
+    {{^status.hasChange}}
+    {{#hasBaseline}}
+    {{status.emoji}} **{{status.text}}**
+    📊 Overall Coverage: {{current.lines}}% (unchanged)
+    {{/hasBaseline}}
+    {{^hasBaseline}}
+    📊 **Overall Coverage**: {{current.lines}}%
+    {{/hasBaseline}}
+    {{/status.hasChange}}
+
+    <details>
+    <summary>📋 Coverage Details</summary>
+
+    {{#hasChangedFiles}}
+    | File | Coverage | Lines |
+    |------|----------|-------|
+    {{#changedFiles}}
+    | {{displayFile}} | {{coverage}}% | {{lines}} |
+    {{/changedFiles}}
+
+    {{/hasChangedFiles}}
+    {{^hasChangedFiles}}
+    *No changed files with coverage data found.*
+
+    {{/hasChangedFiles}}
+    ### Overall Coverage Summary
+    {{#hasBaseline}}
+    - **Lines**: {{current.lines}}% ({{changes.lines.emoji}} {{changes.lines.text}})
+    - **Statements**: {{current.statements}}% ({{changes.statements.emoji}} {{changes.statements.text}})
+    - **Functions**: {{current.functions}}% ({{changes.functions.emoji}} {{changes.functions.text}})
+    - **Branches**: {{current.branches}}% ({{changes.branches.emoji}} {{changes.branches.text}})
+    {{/hasBaseline}}
+    {{^hasBaseline}}
+    - **Lines**: {{current.lines}}%
+    - **Statements**: {{current.statements}}%
+    - **Functions**: {{current.functions}}%
+    - **Branches**: {{current.branches}}%
+    {{/hasBaseline}}
+
+    </details>
+
+    📄 [View Full Coverage Report]({{links.coverageReport}})
+    🔗 [View Workflow Run Summary]({{links.workflowRun}})
+
+    <!-- END_COVERAGE_SECTION -->`;
+    
+    // Get coverage status for overall lines coverage
     const coverageStatus = getCoverageStatus(overall.lines, baseCoverage?.lines);
-    let coverageSection = '### 📊 Test Coverage Report\n\n';
-
-    if (baseCoverage) {
-        if (coverageStatus.diff !== 0) {
-            const diffPrefix = coverageStatus.diff > 0 ? '+' : '-';
-            coverageSection += '```diff\n';
-            coverageSection += `${diffPrefix} 📊 Overall Coverage: ${overall.lines.toFixed(2)}% ${coverageStatus.diff > 0 ? '↑' : '↓'} (baseline: ${baseCoverage.lines.toFixed(2)}%)\n`;
-            coverageSection += '```\n\n';
+    
+    // Calculate changes for all metrics
+    const changes = baseCoverage ? {
+        lines: calculateChange(overall.lines, baseCoverage.lines),
+        statements: calculateChange(overall.statements, baseCoverage.statements),
+        functions: calculateChange(overall.functions, baseCoverage.functions),
+        branches: calculateChange(overall.branches, baseCoverage.branches)
+    } : {};
+    
+    // Process changed files for template
+    const processedChangedFiles = changedFiles.map(file => ({
+        ...file,
+        displayFile: file.file.length > 50 ? `...${file.file.slice(-47)}` : file.file,
+        coverage: file.coverage.toFixed(1),
+        branches: file.branches || 'N/A'
+    }));
+    
+    const avgChangedCoverage = changedFiles.length > 0 
+        ? (changedFiles.reduce((sum, file) => sum + file.coverage, 0) / changedFiles.length).toFixed(1)
+        : 0;
+    
+    // Prepare template data
+    const templateData = {
+        hasBaseline: !!baseCoverage,
+        hasChangedFiles: changedFiles.length > 0,
+        avgChangedCoverage,
+        
+        current: {
+            lines: overall.lines.toFixed(1),
+            functions: overall.functions.toFixed(1),
+            statements: overall.statements.toFixed(1),
+            branches: overall.branches.toFixed(1)
+        },
+        
+        baseline: baseCoverage ? {
+            lines: baseCoverage.lines.toFixed(2),
+            functions: baseCoverage.functions.toFixed(2),
+            statements: baseCoverage.statements.toFixed(2),
+            branches: baseCoverage.branches.toFixed(2)
+        } : null,
+        
+        status: {
+            emoji: coverageStatus.emoji,
+            text: coverageStatus.status,
+            hasChange: coverageStatus.diff !== 0,
+            isIncrease: coverageStatus.diff > 0,
+            isDecrease: coverageStatus.diff < 0,
+            arrow: coverageStatus.diff > 0 ? '↑' : '↓',
+            changeEmoji: coverageStatus.diff > 0 ? '🚀' : '⚠️',
+            changeText: `${Math.abs(coverageStatus.diff).toFixed(1)}% ${coverageStatus.diff > 0 ? 'gain' : 'drop'}`
+        },
+        
+        changes,
+        changedFiles: processedChangedFiles,
+        
+        links: {
+            coverageReport: artifactUrl,
+            workflowRun: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRunId}`
         }
-
-        coverageSection += `${coverageStatus.emoji} **${coverageStatus.status}**\n`;
-        if (coverageStatus.diff !== 0) {
-            const arrow = coverageStatus.diff > 0 ? '↑' : '↓';
-            const gain = coverageStatus.diff > 0 ? 'gain' : 'drop';
-            coverageSection += `📈 Overall Coverage: ${overall.lines.toFixed(1)}% ${arrow}\n`;
-            coverageSection += `${coverageStatus.diff > 0 ? '🚀' : '⚠️'} ${Math.abs(coverageStatus.diff).toFixed(1)}% ${gain} from baseline\n`;
-        } else {
-            coverageSection += `📊 Overall Coverage: ${overall.lines.toFixed(1)}% (unchanged)\n`;
-        }
-    } else {
-        coverageSection += `📊 **Overall Coverage**: ${overall.lines.toFixed(1)}%\n`;
-    }
-
-    coverageSection += '\n<details>\n<summary>📋 Coverage Details</summary>\n\n';
-
-    if (changedFiles.length > 0) {
-        coverageSection += '| File | Coverage | Lines |\n';
-        coverageSection += '|------|----------|-------|\n';
-
-        changedFiles.forEach((file) => {
-            const displayFile = file.file.length > 50 ? `...${file.file.slice(-47)}` : file.file;
-            coverageSection += `| ${displayFile} | ${file.coverage.toFixed(1)}% | ${file.lines} |\n`;
-        });
-        coverageSection += '\n';
-    } else {
-        coverageSection += '*No changed files with coverage data found.*\n\n';
-    }
-
-    coverageSection += '### Overall Coverage Summary\n';
-
-    const formatMetric = (name, current, base) => {
-        if (!base) {
-            return `- **${name}**: ${current.toFixed(2)}%`;
-        }
-        const diff = current - base;
-        if (Math.abs(diff) < 0.01) {
-            return `- **${name}**: ${current.toFixed(2)}%`;
-        }
-        const sign = diff > 0 ? '+' : '';
-        const emoji = diff > 0 ? '📈' : '📉';
-        return `- **${name}**: ${current.toFixed(2)}% (${emoji} ${sign}${diff.toFixed(2)}%)`;
     };
+    
+    return renderTemplate(coverageTemplate, templateData);
+}
 
-    coverageSection += `${formatMetric('Lines', overall.lines, baseCoverage?.lines)}\n`;
-    coverageSection += `${formatMetric('Statements', overall.statements, baseCoverage?.statements)}\n`;
-    coverageSection += `${formatMetric('Functions', overall.functions, baseCoverage?.functions)}\n`;
-
-    coverageSection += '\n</details>\n\n';
-    coverageSection += `📄 [View Full Coverage Report](${artifactUrl})\n`;
-    coverageSection += `🔗 [View Workflow Run Summary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRunId})\n`;
-    coverageSection += `\n${COVERAGE_SECTION_END}`;
-
-    return coverageSection;
+/**
+ * Calculate coverage change with formatting
+ */
+function calculateChange(current, baseline) {
+    const diff = current - baseline;
+    if (Math.abs(diff) < 0.01) {
+        return {
+            text: '→ 0.0%',
+            emoji: '→'
+        };
+    }
+    const arrow = diff > 0 ? '↑' : '↓';
+    const emoji = diff > 0 ? '📈' : '📉';
+    return {
+        text: `${diff > 0 ? '+' : ''}${diff.toFixed(2)}%`,
+        emoji: `${emoji} ${arrow} ${Math.abs(diff).toFixed(1)}%`
+    };
 }
 
 /**
@@ -232,7 +367,7 @@ async function updatePRBody(octokit, prNumber, coverageSection) {
 /**
  * Get coverage report URL - either from direct input or fallback to workflow artifacts
  */
-function getCoverageUrl(coverageUrl, artifactName, workflowRunId) {
+function getCoverageUrl(coverageUrl, workflowRunId) {
     // If we have a direct URL (e.g., from Surge.sh), use it
     if (coverageUrl) {
         return coverageUrl;
@@ -251,7 +386,6 @@ async function run() {
         const octokit = getOctokit(githubToken);
 
         const prNumber = parseInt(core.getInput('PR_NUMBER', {required: true}), 10);
-        const coverageArtifactName = core.getInput('COVERAGE_ARTIFACT_NAME', {required: false}) || 'coverage-report';
         const baseCoveragePath = core.getInput('BASE_COVERAGE_PATH', {required: false});
         const coverageUrl = core.getInput('COVERAGE_URL', {required: false});
         const customTemplatePath = core.getInput('TEMPLATE_PATH', {required: false});
@@ -282,7 +416,7 @@ async function run() {
 
         // Get coverage URL
         const workflowRunId = context.runId.toString();
-        const reportUrl = getCoverageUrl(coverageUrl, coverageArtifactName, workflowRunId);
+        const reportUrl = getCoverageUrl(coverageUrl, workflowRunId);
 
         // Generate coverage section
         const coverageSection = generateCoverageSection(coverageData, reportUrl, workflowRunId, customTemplatePath);

--- a/src/mathUtils.ts
+++ b/src/mathUtils.ts
@@ -281,3 +281,40 @@ export function distance(x1: number, y1: number, x2: number, y2: number): number
     
     return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
 }
+
+/**
+ * Calculate the median of an array of numbers (UNTESTED)
+ */
+export function median(numbers: number[]): number {
+    if (numbers.length === 0) {
+        throw new Error('Cannot calculate median of empty array');
+    }
+    
+    const sorted = [...numbers].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    
+    if (sorted.length % 2 === 0) {
+        return (sorted[middle - 1] + sorted[middle]) / 2;
+    } else {
+        return sorted[middle];
+    }
+}
+
+/**
+ * Check if a year is a leap year (UNTESTED)
+ */
+export function isLeapYear(year: number): boolean {
+    if (year % 4 !== 0) {
+        return false;
+    }
+    
+    if (year % 100 !== 0) {
+        return true;
+    }
+    
+    if (year % 400 === 0) {
+        return true;
+    }
+    
+    return false;
+}


### PR DESCRIPTION
### Explanation of Change
Explain what your change does and how it addresses the linked issue.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>

##


<!-- START_COVERAGE_SECTION -->
### 📊 Test Coverage Report

```diff
- 📊 Overall Coverage: 85.71% ↓ (baseline: 100.00%)
```

🔴 **Coverage dropped!**
📈 Overall Coverage: 85.7% ↓
⚠️ 14.3% drop from baseline

<details>
<summary>📋 Coverage Details</summary>

| File | Coverage | Lines |
|------|----------|-------|
| src/mathUtils.ts | 85.7% | 84/98 |

### Overall Coverage Summary
- **Lines**: 85.71% (📉 -14.29%)
- **Statements**: 85.43% (📉 -14.57%)
- **Functions**: 88.88% (📉 -11.12%)

</details>

📄 [View Full Coverage Report](https://expensify-proposal-testing-coverage-pr16-run16483831308.surge.sh)
🔗 [View Workflow Run Summary](https://github.com/ikevin127/expensify-proposal-testing/actions/runs/16483831308)

<!-- END_COVERAGE_SECTION -->