### PR TITLE
🔫 

### DIFF
--- a/src/CONFIG.ts
+++ b/src/CONFIG.ts
@@ -38,7 +38,7 @@ export default {
     },
     CAPTURE_METRICS: get(Config, 'CAPTURE_METRICS', 'false') === 'true',
     ONYX_METRICS: get(Config, 'ONYX_METRICS', 'false') === 'true',
-    DEV_PORT: process.env.PORT ?? 8082,
+    DEV_PORT: 8082,
     E2E_TESTING: get(Config, 'E2E_TESTING', 'false') === 'true',
     SEND_CRASH_REPORTS: get(Config, 'SEND_CRASH_REPORTS', 'false') === 'true',
     APPLE_SIGN_IN: {
@@ -58,5 +58,7 @@ export default {
     // to read more about StrictMode see: contributingGuides/STRICT_MODE.md
     USE_REACT_STRICT_MODE_IN_DEV: false,
     ELECTRON_DISABLE_SECURITY_WARNINGS: 'true',
-    IS_TEST_ENV: process.env.NODE_ENV === 'test',
+    IS_TEST_ENV: 'test',
+    // Added new config line for demonstration
+    NEW_CONFIG_LINE: 'demo-config',
 } as const;

--- a/src/CONST/LOCALES.ts
+++ b/src/CONST/LOCALES.ts
@@ -41,6 +41,9 @@ const LOCALES = {
     ...BETA_LOCALES,
 } as const;
 
+// Added for demonstration purposes
+const NEW_LOCALE_EXAMPLE = 'example-locale';
+
 /**
  * Locales that are valid translation targets. This does not include English, because it's used as the source of truth.
  */
@@ -87,6 +90,7 @@ export {
     FULLY_SUPPORTED_LOCALES,
     LOCALES,
     LOCALE_TO_LANGUAGE_STRING,
+    NEW_LOCALE_EXAMPLE,
     SORTED_LOCALES,
     TRANSLATION_TARGET_LOCALES,
     isSupportedLocale,

--- a/src/__tests__/mathUtils.test.ts
+++ b/src/__tests__/mathUtils.test.ts
@@ -37,6 +37,8 @@ import {
     sumOfSquares,
     isPerfectNumber,
     logBase,
+    absoluteDifference,
+    isOdd,
 } from '../mathUtils';
 
 describe('Math Utils', () => {
@@ -816,6 +818,28 @@ describe('Math Utils', () => {
         test('should throw error for invalid bases', () => {
             expect(() => logBase(10, 0)).toThrow('Base must be positive and not equal to 1');
             expect(() => logBase(10, 1)).toThrow('Base must be positive and not equal to 1');
+        });
+    });
+
+    describe('absoluteDifference', () => {
+        test('should calculate absolute difference between two numbers', () => {
+            expect(absoluteDifference(5, 3)).toBe(2);
+            expect(absoluteDifference(3, 5)).toBe(2);
+            expect(absoluteDifference(-3, 5)).toBe(8);
+            expect(absoluteDifference(0, 0)).toBe(0);
+        });
+    });
+
+    describe('isOdd', () => {
+        test('should return true for odd numbers', () => {
+            expect(isOdd(1)).toBe(true);
+            expect(isOdd(-3)).toBe(true);
+        });
+
+        test('should return false for even numbers', () => {
+            expect(isOdd(2)).toBe(false);
+            expect(isOdd(0)).toBe(false);
+            expect(isOdd(-4)).toBe(false);
         });
     });
 

--- a/src/libs/requireParameters.ts
+++ b/src/libs/requireParameters.ts
@@ -28,3 +28,13 @@ export default function requireParameters(parameterNames: string[], parameters: 
         throw new Error(error);
     });
 }
+
+// Untested: Returns the first parameter
+export function getFirstParameter(...args: any[]): any {
+    return args[0];
+}
+
+// Untested: Returns the number of parameters
+export function countParameters(...args: any[]): number {
+    return args.length;
+}

--- a/src/mathUtils.ts
+++ b/src/mathUtils.ts
@@ -585,3 +585,17 @@ export function quadraticRoots(a: number, b: number, c: number): { real: number[
         };
     }
 }
+
+/**
+ * Returns the absolute difference between two numbers
+ */
+export function absoluteDifference(a: number, b: number): number {
+    return Math.abs(a - b);
+}
+
+/**
+ * Returns true if a number is odd
+ */
+export function isOdd(n: number): boolean {
+    return n % 2 !== 0;
+}


### PR DESCRIPTION
### Explanation of Change
Explain what your change does and how it addresses the linked issue.

### PR Author Checklist
<!--
This is a checklist for PR authors. Please make sure to complete all tasks and check them off once you do, or else your PR will not be merged!
-->

- [x] I linked the correct issue in the `### Fixed Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
    - [x] I added steps for local testing in the `Tests` section
    - [x] I added steps for the expected offline behavior in the `Offline steps` section
    - [x] I added steps for Staging and/or Production testing in the `QA steps` section
    - [x] I added steps to cover failure scenarios (i.e. verify an input displays the correct error message if the entered data is not correct)
    - [x] I turned off my network connection and tested it while offline to ensure it matches the expected behavior (i.e. verify the default avatar icon is displayed if app is offline)
    - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
    - [x] Android: Native
    - [x] Android: mWeb Chrome
    - [x] iOS: Native
    - [x] iOS: mWeb Safari
    - [x] MacOS: Chrome / Safari
    - [x] MacOS: Desktop
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I verified there are no new alerts related to the `canBeMissing` param for `useOnyx`
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
    - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
    - [x] I verified that comments were added to code that is not self explanatory
    - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
    - [x] I verified any copy / text shown in the product is localized by adding it to `src/languages/*` files and using the [translation method](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L80)
      - [x] If any non-english text was added/modified, I used [JaimeGPT](https://chatgpt.com/g/g-2dgOQl5VM-english-to-spanish-translator-aka-jaimegpt) to get English > Spanish translation. I then posted it in #expensify-open-source and it was approved by an internal Expensify engineer. Link to Slack message:
    - [x] I verified all numbers, amounts, dates and phone numbers shown in the product are using the [localization methods](https://github.com/Expensify/App/blob/4510fc76bbf5df699a2575bfb49a276af90f3ed7/src/components/LocaleContextProvider.tsx#L116-L123)
    - [x] I verified any copy / text that was added to the app is grammatically correct in English. It adheres to proper capitalization guidelines (note: only the first word of header/labels should be capitalized), and is either coming verbatim from figma or has been approved by marketing (in order to get marketing approval, ask the Bug Zero team member to add the Waiting for copy label to the issue)
    - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
    - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.ts or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If any new file was added I verified that:
    - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If a new CSS style is added I verified that:
    - [x] A similar style doesn't already exist
    - [x] The style can't be created with an existing [StyleUtils](https://github.com/Expensify/App/blob/main/src/styles/utils/index.ts) function (i.e. `StyleUtils.getBackgroundAndBorderStyle(theme.componentBG)`)
- [x] If the PR modifies code that runs when editing or sending messages, I tested and verified there is no unexpected behavior for all supported markdown - URLs, single line code, code blocks, quotes, headings, bold, strikethrough, and italic.
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the PR modifies a component related to any of the existing Storybook stories, I tested and verified all stories for that component are still working as expected.
- [x] If the PR modifies a component or page that can be accessed by a direct deeplink, I verified that the code functions as expected when the deeplink is used - from a logged in and logged out account.
- [x] If the PR modifies the UI (e.g. new buttons, new UI components, changing the padding/spacing/sizing, moving components, etc) or modifies the form input styles:
    - [x] I verified that all the inputs inside a form are aligned with each other.
    - [x] I added `Design` label and/or tagged `@Expensify/design` so the design team can review the changes.
- [x] If a new page is added, I verified it's using the `ScrollView` component to make it scrollable when more elements are added to the page.
- [x] I added [unit tests](https://github.com/Expensify/App/blob/main/tests/README.md) for any new feature or bug fix in this PR to help automatically prevent regressions in this user flow.
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.

### Screenshots/Videos
<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Desktop</summary>

<!-- add screenshots or videos here -->

</details>

<!-- START_COVERAGE_SECTION -->
## 📊 Test Coverage Report

### 🔴 **Coverage dropped**

```diff
- 📉 Overall Coverage: ↓ 82.9% (main: 83.6%)
```

> [!CAUTION]
> ⚠️ **0.6% decrease from main**

<details>
<summary><strong>📁 Coverage details</strong></summary>
<br>

| File | Coverage | Lines |
|------|----------|-------|
| `src/mathUtils.ts` | 89.1% | 180/202 || `src/CONFIG.ts` | 0.0% | 0/0 || `src/CONST/LOCALES.ts` | 0.0% | 0/0 || `src/libs/requireParameters.ts` | 0.0% | 0/15 |


**🔄 Overall Coverage Summary**

- **Lines**: 82.9% (-0.6%)
- **Statements**: 82.5% (-0.6%)
- **Functions**: 81.1% (-2.5%)



</details>

📄 [View Web Report](https://expensify-proposal-testing-coverage-pr61-run16687304621.surge.sh)
⚙️ [View Workflow Run](https://github.com/ikevin127/expensify-proposal-testing/actions/runs/16687304621)

<!-- END_COVERAGE_SECTION -->